### PR TITLE
allow multiple locations for the global rbenv version file.

### DIFF
--- a/rbenv.el
+++ b/rbenv.el
@@ -58,7 +58,7 @@
 (defvar rbenv-executable (expand-file-name "~/.rbenv/bin/rbenv")
   "path to the rbenv executable")
 
-(defvar rbenv-global-version-file (expand-file-name "~/.rbenv/version")
+(defvar rbenv-global-version-files (list (rbenv--expand-path "version") "/usr/local/rbenv")
   "path to the global version configuration file of rbenv")
 
 (defvar rbenv-version-environment-variable "RBENV_VERSION"
@@ -136,7 +136,12 @@
   (rbenv--expand-path "versions" ruby-version "bin"))
 
 (defun rbenv--global-ruby-version ()
-  (rbenv--read-version-from-file rbenv-global-version-file))
+  (let* ((global-ruby-versions (mapcar (lambda (version-file-path)
+                                         (when (file-exists-p version-file-path)
+                                           (rbenv--read-version-from-file version-file-path))) rbenv-global-version-files))
+         (global-ruby-version (first (remove-if nil global-ruby-versions))))
+    (if global-ruby-version global-ruby-version
+      (error "[rbenv] could not detect global ruby version. Check your rbenv-global-version-files variable"))))
 
 (defun rbenv--read-version-from-file (path)
   (with-temp-buffer


### PR DESCRIPTION
closes #2

By default rbenv.el will check for the global version file in the following locations:
- ~/.rbenv/version
- /usr/local/rbenv

You can modify the list `rbenv-global-version-files` to change the locations where rbenv.el
will look for your global version file.
