### PR TITLE
Add a variable to the Ruby shim in the rbenv installation.

### DIFF
--- a/rbenv.el
+++ b/rbenv.el
@@ -68,6 +68,9 @@
 
 (defvar rbenv-executable (rbenv--expand-path "bin" "rbenv")
   "path to the rbenv executable")
+  
+(defvar rbenv-ruby-shim (rbenv--expand-path "shims" "ruby")
+  "path to the ruby shim executable")
 
 (defvar rbenv-global-version-file (rbenv--expand-path "version")
   "path to the global version configuration file of rbenv")


### PR DESCRIPTION
For some major modes they maintain their own list or variables to the ruby interpreters. The main one that comes to mind is the enhanced-ruby-mode. A better path may be to actually refactor this, but I do not see any harm adding this variable in the meanwhile. 
