### PR TITLE
Update the rbenv-installation-dir to pull from RBENV_ROOT.

### DIFF
--- a/rbenv.el
+++ b/rbenv.el
@@ -40,7 +40,8 @@
 ;;; Compiler support:
 
 ;; helper function used in variable definitions
-(defcustom rbenv-installation-dir (concat (getenv "HOME") "/.rbenv/")
+(defcustom rbenv-installation-dir (or (getenv "RBENV_ROOT")
+                                      (concat (getenv "HOME") "/.rbenv/"))
   "The path to the directory where rbenv was installed."
   :group 'rbenv
   :type 'directory)


### PR DESCRIPTION
The RBENV_ROOT environment variable is actually set by rbenv. For users
of GitHub's Boxen project this is installed to
/opt/boxen/rbenv. Additionally the same problem becomes present on
corporate machines where often we only want to install rubies once.
