### PR TITLE
Use default-directory instead of buffer-file-name

### DIFF
--- a/rbenv.el
+++ b/rbenv.el
@@ -157,7 +157,7 @@
 
 (defun rbenv--locate-file (file-name)
   "searches the directory tree for an given file. Returns nil if the file was not found."
-  (let ((directory (locate-dominating-file (expand-file-name buffer-file-name) file-name)))
+  (let ((directory (locate-dominating-file default-directory file-name)))
     (when directory (concat directory file-name))))
 
 (defun rbenv--call-process (&rest args)


### PR DESCRIPTION
`buffer-file-name` doesn't work for non-file buffers, so `rbenv-use-corresponding` currently doesn't work for shell buffers and whatnot. I think `default-directory` is better in any case--when you use `rbenv-use-corresponding`, it makes sense for it to act on the current directory (like the original rbenv script).
