### PR TITLE
Correctly read .ruby-version with trailing newline

### DIFF
--- a/rbenv.el
+++ b/rbenv.el
@@ -175,7 +175,7 @@
         (message output)))))
 
 (defun rbenv--replace-trailing-whitespace (text)
-  (replace-regexp-in-string "[[:space:]]\\'" "" text))
+  (replace-regexp-in-string "[[:space:]\n]+\\'" "" text))
 
 (defun rbenv--update-mode-line ()
   (setq rbenv--modestring (funcall rbenv-modeline-function


### PR DESCRIPTION
The shell version of rbenv will ignore trailing newlines in
.ruby-version files; this changes rbenv.el to do the same.
