### PR TITLE
rbenv installed with homebrew

### DIFF
--- a/rbenv.el
+++ b/rbenv.el
@@ -40,8 +40,11 @@
 ;;; Compiler support:
 
 ;; helper function used in variable definitions
-(defcustom rbenv-installation-dir (or (getenv "RBENV_ROOT")
-                                      (concat (getenv "HOME") "/.rbenv/"))
+(defcustom rbenv-installation-dir (or (and (string-equal system-type "darwin")
+                                      (file-directory-p "/usr/local/opt/rbenv")
+                                      "/usr/local/opt/rbenv/")
+                                 (getenv "RBENV_ROOT")
+                                 (concat (getenv "HOME") "/.rbenv/"))
   "The path to the directory where rbenv was installed."
   :group 'rbenv
   :type 'directory)


### PR DESCRIPTION
After using rbenv installed on MAC OSX with homebrew, the bin directory is not located in

`~/.rbenv/bin`

instead of that the homebrew creates a symlink in:

```
ls -lh /usr/local/opt/ | rg rbenv
lrwxr-xr-x  1 toni  admin    21B 25 feb 13:11 rbenv -> ../Cellar/rbenv/1.1.2
```
So I checked that emacs is on OSX, and it is installed with homebrew, if that not pass it uses the older implementation since rbenv installtion on MAC OSX [recommend to use homebrew](https://github.com/rbenv/rbenv#homebrew-on-macos)

Hope this helps
